### PR TITLE
Fix Codesandbox SSL plugin conflict

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import basicSsl from "@vitejs/plugin-basic-ssl";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), basicSsl()],
+  plugins: [react(), process.env.NODE_ENV === "development" && basicSsl()],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import basicSsl from "@vitejs/plugin-basic-ssl";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), process.env.NODE_ENV === "development" && basicSsl()],
+  plugins: [react(), !process.env.CODESANDBOX_HOST && basicSsl()],
 });


### PR DESCRIPTION
Codesandbox didn't like the `basicSsl()` vite plugin so we're using a Codesandbox-specific env variable to avoid loading this plugin when the app is loaded there. This will allow us to both develop/test locally and in Codesandbox 🎊 