### PR TITLE
APPS-634 App Template: add new npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview --host",
-    "watch": "tsc && (vite preview --host &) && vite build --watch"
+    "watch": "tsc && vite preview --host & && vite build --watch"
   },
   "dependencies": {
     "@helpscout/javascript-sdk": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview --host",
-    "watch": "tsc && vite preview --host & && vite build --watch"
+    "watch": "tsc && (vite preview --host &) && vite build --watch"
   },
   "dependencies": {
     "@helpscout/javascript-sdk": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview --host",
+    "watch": "tsc && (vite preview --host &) && vite build --watch"
   },
   "dependencies": {
     "@helpscout/javascript-sdk": "^0.2.1",


### PR DESCRIPTION
[Jira issue](https://helpscout.atlassian.net/browse/APPS-634)

### Problem

Because of the changes done in [HSAPP-8506](https://helpscout.atlassian.net/browse/HSAPP-8506), we can’t use npm run dev to start our local Vite apps anymore. We need the app to be built (for production) and exposed through a network IP.

This can be achieved by running `npm run build && npm run preview -- --host`, but we don't want developers to have to know that...

### Solution

Add a new npm script to watch for code changes, build and start the app with the --host param.

I've also update the other scripts to include the `--host` param, just in case someone uses them. 😬 

### Testing

1. Run the script by executing `npm run watch`
    - [x] You can see in the output that the app is built and a network host is provided
2. Change the main app component somehow
    - [x] You can see in the output that the app is rebuilt

[HSAPP-8506]: https://helpscout.atlassian.net/browse/HSAPP-8506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ