### PR TITLE
EXP-23054: Update README.md to reflect CodeSandbox preview problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ This is a basic starter template for building a Help Scout Sidebar App. It uses 
 - Callback URL: the URL of your environment you copied previously
 - Secret Key: any text value
 - Mailboxes: select the mailboxes where you want this app to be available in
-8. Go to one of the Mailboxes you selected in the previous step and open a conversation. You should see your app running in the right Sidebar.
+8. Go to one of the Mailboxes you selected in the previous step and open a conversation. You'll see an app container with your app's title and string of query parameters, which is Codesandbox's (very confusing) initial preview confirmation. Focus the container and either use `Tab` navigation or search for the text Preview to get access to [this button](https://github.com/user-attachments/assets/16d07470-37d3-42d0-b85d-0a21d6c000c6), then hit `Enter`. You should now see your app rendered.
 9. Now you can start making changes to your app in CodeSandbox and you should see those changes reflected immediately in Help Scout.
+
+
+
 
 ## 🛠️ Resources
 


### PR DESCRIPTION
https://linear.app/helpscout/issue/EXP-23054/update-custom-app-templates-public-documentation

See [this HS conversation](https://secure.helpscout.net/conversation/2831166996/1158315), but tl;dr, CodeSandbox have now added a Preview confirmation that you have to click through before your app is rendered, but the way they designed that + the size of the custom app means that it just looks broken and it's not clear that you just have to confirm.

Since it's an iframe, I don't know if there's anything we can do to make it look less broken (other than stop recommending CodeSandbox) but at least as a stopgap we can let people know so they can figure it out themselves instead of thinking their app is broken (thanks for the suggestion, Chrissy!)